### PR TITLE
feat(docker): add build context for server/client service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,10 @@ services:
   client:
     restart: always
     build:
+      context: .
       dockerfile: client.Dockerfile
+      args:
+        BUILDKIT_INLINE_CACHE: 0
     environment:
       - OTEL_LOG_LEVEL=debug
       - OTEL_METRICS_EXPORTER=otlp
@@ -14,11 +17,15 @@ services:
       - OTEL_EXPORTER_OTLP_PROTOCOL=grpc
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://oteldb:4317
       - OTEL_RESOURCE_ATTRIBUTES=service.name=client
+
   server:
     restart: always
     command: ["server"]
     build:
+      context: .
       dockerfile: server.Dockerfile
+      args:
+        BUILDKIT_INLINE_CACHE: 0
     environment:
       - OTEL_LOG_LEVEL=debug
       - OTEL_METRICS_EXPORTER=otlp


### PR DESCRIPTION
This commit adds the build context configuration for the server and client services in the docker-compose.yml file. The context is set to the current directory ('.'), allowing Docker to access all necessary files for building the server/client image.

Fixes #176